### PR TITLE
fixed currying functions that uses func_get_args()

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit
-        bootstrap                   = "vendor/autoload.php"
         backupGlobals               = "false"
         backupStaticAttributes      = "false"
         colors                      = "true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit
+        bootstrap                   = "vendor/autoload.php"
         backupGlobals               = "false"
         backupStaticAttributes      = "false"
         colors                      = "true"

--- a/src/Cypress/Curry/functions.php
+++ b/src/Cypress/Curry/functions.php
@@ -8,6 +8,8 @@ namespace Cypress\Curry;
  */
 function curry($callable)
 {
+    if (_number_of_required_params($callable) < 2)
+        return $callable;
     return _curry_array_args($callable, _rest(func_get_args()));
 }
 
@@ -92,7 +94,7 @@ function _rest(array $args)
  */
 function _is_fullfilled($callable, $args)
 {
-    return count($args) === _number_of_required_params($callable);
+    return count($args) >= _number_of_required_params($callable);
 }
 
 /**

--- a/src/Cypress/Curry/functions.php
+++ b/src/Cypress/Curry/functions.php
@@ -30,6 +30,8 @@ function curry_args($callable, array $args)
  */
 function curry_right($callable)
 {
+    if (_number_of_required_params($callable) < 2)
+        return _make_function($callable);
     return _curry_array_args($callable, _rest(func_get_args()), false);
 }
 

--- a/src/Cypress/Curry/functions.php
+++ b/src/Cypress/Curry/functions.php
@@ -9,7 +9,7 @@ namespace Cypress\Curry;
 function curry($callable)
 {
     if (_number_of_required_params($callable) < 2)
-        return $callable;
+        return _make_function($callable);
     return _curry_array_args($callable, _rest(func_get_args()));
 }
 
@@ -111,4 +111,21 @@ function _number_of_required_params($callable)
     }
     $refl = new \ReflectionFunction($callable);
     return $refl->getNumberOfRequiredParameters();
+}
+
+/**
+ * if the callback is an array(instance, method), 
+ * it returns an equivalent function for PHP 5.3 compatibility.
+ *
+ * @internal 
+ * @param  callable $callable
+ * @return callable
+ */
+function _make_function($callable)
+{
+    if (is_array($callable))
+        return function() use($callable) {
+            return call_user_func_array($callable, func_get_args());
+        };
+    return $callable;
 }

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -106,6 +106,25 @@ class functionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $divideBy10And5(100));
     }
 
+    public function test_curry_using_func_get_args()
+    {
+        $fnNoArgs = C\curry(function () { return func_get_args(); });
+        $this->assertEquals([], $fnNoArgs());
+        $this->assertEquals([1], $fnNoArgs(1));
+        $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
+
+        $fnOneArg = C\curry(function ($x) { return func_get_args(); });
+        $this->assertEquals([1], $fnNoArgs(1));
+        $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
+
+        $fnTwoArgs = C\curry(function ($x, $y) { return func_get_args(); });
+        $curried = $fnTwoArgs(1);
+        $this->assertEquals([1, 2], $fnNoArgs(1, 2));
+        $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
+        $this->assertEquals([1, 2], $curried(2));
+        $this->assertEquals([1, 2, 'three'], $curried(2, 'three'));
+    }
+
     public function test_rest()
     {
         $this->assertEquals(array(1), C\_rest(array(1, 1)));

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -109,20 +109,20 @@ class functionsTest extends \PHPUnit_Framework_TestCase
     public function test_curry_using_func_get_args()
     {
         $fnNoArgs = C\curry(function () { return func_get_args(); });
-        $this->assertEquals([], $fnNoArgs());
-        $this->assertEquals([1], $fnNoArgs(1));
-        $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
+        $this->assertEquals(array(), $fnNoArgs());
+        $this->assertEquals(array(1), $fnNoArgs(1));
+        $this->assertEquals(array(1, 2, 'three'), $fnNoArgs(1, 2, 'three'));
 
         $fnOneArg = C\curry(function ($x) { return func_get_args(); });
-        $this->assertEquals([1], $fnNoArgs(1));
-        $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
+        $this->assertEquals(array(1), $fnNoArgs(1));
+        $this->assertEquals(array(1, 2, 'three'), $fnNoArgs(1, 2, 'three'));
 
         $fnTwoArgs = C\curry(function ($x, $y) { return func_get_args(); });
         $curried = $fnTwoArgs(1);
-        $this->assertEquals([1, 2], $fnNoArgs(1, 2));
-        $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
-        $this->assertEquals([1, 2], $curried(2));
-        $this->assertEquals([1, 2, 'three'], $curried(2, 'three'));
+        $this->assertEquals(array(1, 2), $fnNoArgs(1, 2));
+        $this->assertEquals(array(1, 2, 'three'), $fnNoArgs(1, 2, 'three'));
+        $this->assertEquals(array(1, 2), $curried(2));
+        $this->assertEquals(array(1, 2, 'three'), $curried(2, 'three'));
     }
 
     public function test_rest()

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -108,21 +108,56 @@ class functionsTest extends \PHPUnit_Framework_TestCase
 
     public function test_curry_using_func_get_args()
     {
-        $fnNoArgs = C\curry(function () { return func_get_args(); });
+
+        $fnNoArgs = function () { return func_get_args(); };
+        $curried = C\curry($fnNoArgs);
+        $curriedRight = C\curry_right($fnNoArgs);
+
         $this->assertEquals(array(), $fnNoArgs());
-        $this->assertEquals(array(1), $fnNoArgs(1));
-        $this->assertEquals(array(1, 2, 'three'), $fnNoArgs(1, 2, 'three'));
+        $this->assertEquals(array(), $curried());
+        $this->assertEquals(array(), $curriedRight());
 
-        $fnOneArg = C\curry(function ($x) { return func_get_args(); });
         $this->assertEquals(array(1), $fnNoArgs(1));
-        $this->assertEquals(array(1, 2, 'three'), $fnNoArgs(1, 2, 'three'));
+        $this->assertEquals(array(1), $curried(1));
+        $this->assertEquals(array(1), $curriedRight(1));
 
-        $fnTwoArgs = C\curry(function ($x, $y) { return func_get_args(); });
-        $curried = $fnTwoArgs(1);
-        $this->assertEquals(array(1, 2), $fnNoArgs(1, 2));
         $this->assertEquals(array(1, 2, 'three'), $fnNoArgs(1, 2, 'three'));
-        $this->assertEquals(array(1, 2), $curried(2));
-        $this->assertEquals(array(1, 2, 'three'), $curried(2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curried(1, 2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curriedRight(1, 2, 'three'));
+
+        $fnOneArg = function ($x) { return func_get_args(); };
+        $curried = C\curry($fnOneArg);
+        $curriedRight = C\curry_right($fnOneArg);
+
+        $this->assertEquals(array(1), $fnOneArg(1));
+        $this->assertEquals(array(1), $curried(1));
+        $this->assertEquals(array(1), $curriedRight(1));
+
+        $this->assertEquals(array(1, 2, 'three'), $fnOneArg(1, 2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curried(1, 2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curriedRight(1, 2, 'three'));
+
+        $fnTwoArgs = function ($x, $y) { return func_get_args(); };
+        $curried = C\curry($fnTwoArgs);
+        $curriedRight = C\curry_right($fnTwoArgs);
+
+        $curriedOne = $curried(1); 
+        $curriedRightOne = $curriedRight(2);
+        $curriedRightTwo = $curriedRight('three');
+
+        $this->assertEquals(array(1, 2), $fnTwoArgs(1, 2));
+        $this->assertEquals(array(1, 2), $curried(1, 2));
+        $this->assertEquals(array(1, 2), $curriedRight(2, 1));
+
+        $this->assertEquals(array(1, 2, 'three'), $fnTwoArgs(1, 2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curried(1, 2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curriedRight('three', 2, 1));
+
+        $this->assertEquals(array(1, 2), $curriedOne(2));
+        $this->assertEquals(array(1, 2), $curriedRightOne(1));
+
+        $this->assertEquals(array(1, 2, 'three'), $curriedOne(2, 'three'));
+        $this->assertEquals(array(1, 2, 'three'), $curriedRightTwo(2, 1));
     }
 
     public function test_rest()


### PR DESCRIPTION
Hello, I added this test case

``` php
public function test_curry_using_func_get_args()
{
    $fnNoArgs = C\curry(function () { return func_get_args(); });
    $this->assertEquals([], $fnNoArgs());
    $this->assertEquals([1], $fnNoArgs(1));
    $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));

    $fnOneArg = C\curry(function ($x) { return func_get_args(); });
    $this->assertEquals([1], $fnNoArgs(1));
    $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));

    $fnTwoArgs = C\curry(function ($x, $y) { return func_get_args(); });
    $curried = $fnTwoArgs(1);
    $this->assertEquals([1, 2], $fnNoArgs(1, 2));
    $this->assertEquals([1, 2, 'three'], $fnNoArgs(1, 2, 'three'));
    $this->assertEquals([1, 2], $curried(2));
    $this->assertEquals([1, 2, 'three'], $curried(2, 'three'));
}
```

And fixed the code to make it pass.
