### PR TITLE
argument placeholder added

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,24 @@ var_dump(array_map(function ($finder) {
 ```
 
 *curry_right* have its fixed version named *curry_right_fixed*
+
+### Placeholders
+
+The function `__()` gets a special placeholder value used to specify "gaps" within curried functions, allowing partial application of any combination of arguments, regardless of their positions.
+
+```php
+$add = function($x, $y)
+{ 
+	return $x + $y; 
+};
+$reduce = C\curry('array_reduce');
+$sum = $reduce(C\__(), $add);
+
+echo $sum([1, 2, 3, 4], 0); // output 10
+```
+
+**Notes**:
+
+- Placeholders hould be used only for required arguments.
+
+- When used, optional arguments must be at the end of the arguments list.

--- a/src/Cypress/Curry/Placeholder.php
+++ b/src/Cypress/Curry/Placeholder.php
@@ -1,0 +1,21 @@
+<?php
+namespace Cypress\Curry;
+
+/**
+ * This class is created simply to define a special type 
+ * for the placeholder. As defining a constant, even 
+ * a random one, could collide with other values.
+ */
+class Placeholder {
+	private static $instance;
+	private function __construct(){}
+	public function get()
+	{
+		if(static::$instance === null)
+			static::$instance = new Placeholder;
+		return static::$instance;
+	}
+	public function __toString(){
+		return '__';
+	}
+}

--- a/src/Cypress/Curry/Placeholder.php
+++ b/src/Cypress/Curry/Placeholder.php
@@ -9,7 +9,7 @@ namespace Cypress\Curry;
 class Placeholder {
 	private static $instance;
 	private function __construct(){}
-	public function get()
+	public static function get()
 	{
 		if(static::$instance === null)
 			static::$instance = new Placeholder;

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -160,6 +160,36 @@ class functionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(1, 2, 'three'), $curriedRightTwo(2, 1));
     }
 
+    public function test_curry_with_placeholders()
+    {
+        $minus = C\curry(function ($x, $y) { return $x - $y; });
+        $decrement = $minus(C\__(), 1);
+
+        $this->assertEquals(9, $decrement(10));
+
+        $introduce = C\curry(function($name, $age, $job, $details = '') {
+            return "{$name}, {$age} years old, is a {$job} {$details}";
+        });
+
+        $introduceDeveloper = $introduce(C\__(), C\__(), 'Developer');
+        $this->assertEquals("Foo, 20 years old, is a Developer ", $introduceDeveloper('Foo', 20));
+
+        $introduceOld = $introduce(C\__(), 99, C\__());
+        $this->assertEquals("Foo, 99 years old, is a Developer and Cooker as well", $introduceOld('Foo', 'Developer', 'and Cooker as well'));
+
+        $introduceSkipName = $introduce(C\__());
+        $introduceSkipJob = $introduceSkipName(99, C\__());
+
+        $this->assertEquals("Foo, 99 years old, is a Cooker ", $introduceSkipJob('Foo', 'Cooker'));
+        $this->assertEquals("Foo, 99 years old, is a Cooker yumm !", $introduceSkipJob('Foo', 'Cooker', 'yumm !'));
+
+        $reduce = C\curry('array_reduce');
+        $add = function($x, $y){ return $x + $y; };
+        $sum = $reduce(C\__(), $add);
+
+        $this->assertEquals(10, $sum([1, 2, 3, 4], 0));
+    }
+
     public function test_rest()
     {
         $this->assertEquals(array(1), C\_rest(array(1, 1)));

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -187,7 +187,7 @@ class functionsTest extends \PHPUnit_Framework_TestCase
         $add = function($x, $y){ return $x + $y; };
         $sum = $reduce(C\__(), $add);
 
-        $this->assertEquals(10, $sum([1, 2, 3, 4], 0));
+        $this->assertEquals(10, $sum(array(1, 2, 3, 4), 0));
     }
 
     public function test_rest()


### PR DESCRIPTION
Hello, I added a new feature which is argument placeholder. inspired from [Ramdajs](http://ramdajs.com/0.21.0/docs/#__). This will allow doing things like:

``` php
$minus = C\curry(function ($x, $y) { return $x - $y; });
$decrement = $minus(C\__(), 1);
$this->assertEquals(9, $decrement(10));
```
