### PR TITLE
Implementation of a fixed number of argument for curry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ echo $divide10By(10); // output 1
 echo $divideBy10(100); // output 10
 ```
 
+**Caveat** Only the required arguments go from right, optional argument are apppended (from left).
+
+``` php
+$divider = function ($a, $b, $decimals = 0, $dec_point = '.') {
+    return number_format($a / $b, $decimals, $dec_point);
+};
+
+$divide10By = C\curry($divider, 10);
+$divideBy10 = C\curry_right($divider, 10);
+
+echo $divide10By(10, 2, ','); // output 1,00
+echo $divideBy10(100, 2, ','); // output 10,00
+```
+
 ### Parameters as an array
 
 You can also curry a function and pass the parameters as an array, just use the \*_args version of the function.
@@ -77,33 +91,6 @@ echo $division(); // output 10
 $division2 = C\curry_right_args($divider, [100, 10]);
 echo $division2(); // output 0.1
 ```
-
-### Optional parameters
-
-Optional parameters and currying do not play very nicely together. This library excludes optional parameters by default.
-
-``` php
-$haystack = "haystack";
-$searches = ['h', 'a', 'z'];
-$strpos = C\curry('strpos', $haystack); // You can pass function as string too!
-var_dump(array_map($strpos, $searches)); // output [0, 1, false]
-```
-
-But strpos has an optional $offset parameter that by default has not been considered.
-
-If you want to take this optional $offset parameter into account you should "fix" the curry to a given length.
-
-``` php
-$haystack = "haystack";
-$searches = ['h', 'a', 'z'];
-$strpos = C\curry_fixed(3, 'strpos', $haystack);
-$finders = array_map($strpos, $searches);
-var_dump(array_map(function ($finder) {
-    return $finder(2);
-}, $finders)); // output [false, 5, false]
-```
-
-*curry_right* has its own fixed version named *curry_right_fixed*
 
 ### Placeholders
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ $division2 = C\curry_right_args($divider, [100, 10]);
 echo $division2(); // output 0.1
 ```
 
+### Fixed number of parameters
+
+You can should "fix" the curry to a given length by starting with the number of arguments.
+
+This can be used to make sure the curry ignores optional arguments or to set optional arguments when creating the curry.
+
+``` php
+$divider = function ($a, $b, $c = 1) {
+    return $a / ($b * $c);
+};
+
+$divide10ByProduct = C\curry(2, $divider, 10);
+$divideByTripple = C\curry_right(2, $divider, 3);
+$divideBy200 = C\curry_right(1, $divider, 10, 20);
+```
+
 ### Placeholders
 
 The function `__()` gets a special placeholder value used to specify "gaps" within curried functions, allowing partial application of any combination of arguments, regardless of their positions.

--- a/README.md
+++ b/README.md
@@ -97,18 +97,13 @@ echo $division2(); // output 0.1
 The function `__()` gets a special placeholder value used to specify "gaps" within curried functions, allowing partial application of any combination of arguments, regardless of their positions.
 
 ```php
-$add = function($x, $y)
-{ 
-	return $x + $y; 
-};
-$reduce = C\curry('array_reduce');
-$sum = $reduce(C\__(), $add);
+use Cypress\Curry as C;
 
-echo $sum([1, 2, 3, 4], 0); // output 10
+$redact = C\curry('str_replace', C\__(), "***", C\__());
+
+$text = "Jack and Jill went up the hill to fetch a pail of water. Jack fell down and broke his crown and Jill came tumbling after.";
+
+echo $redact(['Jack', 'Jill'], $text);
+// *** and *** went up the hill to fetch a pail of water. *** fell down and broke his crown and *** came tumbling after.
 ```
 
-**Notes**:
-
-- Placeholders should be used only for required arguments.
-
-- When used, optional arguments must be at the end of the arguments list.

--- a/src/Cypress/Curry/Placeholder.php
+++ b/src/Cypress/Curry/Placeholder.php
@@ -5,6 +5,8 @@ namespace Cypress\Curry;
  * This class is created simply to define a special type 
  * for the placeholder. As defining a constant, even 
  * a random one, could collide with other values.
+ *
+ * @internal
  */
 class Placeholder {
 	private static $instance;

--- a/src/Cypress/Curry/functions.php
+++ b/src/Cypress/Curry/functions.php
@@ -89,7 +89,7 @@ function _execute($callable, $args, $left)
     $placeholders = _placeholder_positions($args);
     if (0 < count($placeholders)) {
         $n = _number_of_required_params($callable);
-        if ($n <= _last($placeholders[count($placeholders) - 1])) {
+        if ($n <= _last($placeholders)) {
             // This means that we have more placeholders then needed
             // I know that throwing exceptions is not really the 
             // functional way, but this case should not happen.

--- a/src/Cypress/Curry/functions.php
+++ b/src/Cypress/Curry/functions.php
@@ -86,9 +86,10 @@ function _execute($callable, $args, $left)
         $args = array_reverse($args);
     }
 
+    $n = _number_of_required_params($callable);
+
     $placeholders = _placeholder_positions($args);
     if (0 < count($placeholders)) {
-        $n = _number_of_required_params($callable);
         if ($n <= _last($placeholders)) {
             // This means that we have more placeholders then needed
             // I know that throwing exceptions is not really the 
@@ -99,6 +100,11 @@ function _execute($callable, $args, $left)
             $args[$i] = $args[$n];
             array_splice($args, $n, 1);
         }
+    }
+
+    if (count($args) > $n) {
+        $extra = array_splice($args, $left ? $n : 0, count($args) - $n);
+        $args = array_merge($args, $left ? $extra : array_reverse($extra));
     }
 
     return call_user_func_array($callable, $args);

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -22,13 +22,13 @@ class functionsTest extends TestCase
     public function test_curry_identity()
     {
         $identity = C\curry(array(new TestSubject(), 'identity'), 1);
-        $this->assertEquals(1, $identity(1));
+        $this->assertEquals(1, $identity());
     }
 
-    public function test_curry_identity_without_params()
+    public function test_curry_identity_with_additional_arg()
     {
         $identity = C\curry(array(new TestSubject(), 'identity'), 1);
-        $this->assertEquals(1, $identity());
+        $this->assertEquals(1, $identity(10));
     }
 
     public function test_curry_identity_function()
@@ -46,7 +46,7 @@ class functionsTest extends TestCase
     public function test_curry_args_identity()
     {
         $identity = C\curry_args(array(new TestSubject(), 'identity'), array(1));
-        $this->assertEquals(1, $identity(1));
+        $this->assertEquals(1, $identity());
     }
 
     public function test_curry_with_one_later_param()
@@ -54,6 +54,13 @@ class functionsTest extends TestCase
         $curriedOne = C\curry(array(new TestSubject(), 'add2'), 1);
         $this->assertInstanceOf('Closure', $curriedOne);
         $this->assertEquals(2, $curriedOne(1));
+    }
+
+    public function test_curry_with_additional_arg()
+    {
+        $curriedOne = C\curry(array(new TestSubject(), 'add2'), 1);
+        $this->assertInstanceOf('Closure', $curriedOne);
+        $this->assertEquals(3, $curriedOne(2, 7));
     }
 
     public function test_curry_with_two_later_param()
@@ -82,6 +89,13 @@ class functionsTest extends TestCase
         $divideBy10 = C\curry_right(array(new TestSubject(), 'divide2'), 10);
         $this->assertInstanceOf('Closure', $divideBy10);
         $this->assertEquals(10, $divideBy10(100));
+    }
+
+    public function test_curry_right_additional_arg()
+    {
+        $divideBy10 = C\curry_right(array(new TestSubject(), 'divide2'), 10);
+        $this->assertInstanceOf('Closure', $divideBy10);
+        $this->assertEquals(10, $divideBy10(100, 20));
     }
 
     public function test_curry_right_args()
@@ -167,7 +181,6 @@ class functionsTest extends TestCase
 
         $curriedOne = $curried(1); 
         $curriedRightOne = $curriedRight(2);
-        $curriedRightTwo = $curriedRight('three');
 
         $this->assertEquals(array(1, 2), $fnTwoArgs(1, 2));
         $this->assertEquals(array(1, 2), $curried(1, 2));
@@ -175,13 +188,13 @@ class functionsTest extends TestCase
 
         $this->assertEquals(array(1, 2, 'three'), $fnTwoArgs(1, 2, 'three'));
         $this->assertEquals(array(1, 2, 'three'), $curried(1, 2, 'three'));
-        $this->assertEquals(array(1, 2, 'three'), $curriedRight('three', 2, 1));
+        $this->assertEquals(array(1, 2, 'three'), $curriedRight(2, 1, 'three'));
 
         $this->assertEquals(array(1, 2), $curriedOne(2));
         $this->assertEquals(array(1, 2), $curriedRightOne(1));
 
         $this->assertEquals(array(1, 2, 'three'), $curriedOne(2, 'three'));
-        $this->assertEquals(array(1, 2, 'three'), $curriedRightTwo(2, 1));
+        $this->assertEquals(array(1, 2, 'three', 'IV'), $curriedRightOne(1, 'three', 'IV'));
     }
 
     public function test_curry_with_placeholders()

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -2,7 +2,6 @@
 
 namespace test\Cypress\Curry;
 
-use Cypress\Curry\CurriedFunction;
 use Cypress\Curry as C;
 use PHPUnit\Framework\TestCase;
 
@@ -14,10 +13,22 @@ class functionsTest extends TestCase
         $this->assertEquals(1, $simpleFunction());
     }
 
+    public function test_curry_constant()
+    {
+        $constant = C\curry(array(new TestSubject(), 'constant'));
+        $this->assertEquals(1, $constant());
+    }
+
     public function test_curry_identity()
     {
         $identity = C\curry(array(new TestSubject(), 'identity'), 1);
         $this->assertEquals(1, $identity(1));
+    }
+
+    public function test_curry_identity_without_params()
+    {
+        $identity = C\curry(array(new TestSubject(), 'identity'), 1);
+        $this->assertEquals(1, $identity());
     }
 
     public function test_curry_identity_function()
@@ -231,10 +242,32 @@ class functionsTest extends TestCase
             array(true, array('aaa', 'a'), 'strpos'),
         );
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Argument Placeholder found on unexpected position !
+     */
+    public function test_unexpected_placeholder()
+    {
+        $fn = C\curry(function($a) { }, 22, C\__());
+        $fn(20);
+    }
+
+    public function test_placeholder()
+    {
+        $placeholder = C\Placeholder::get();
+
+        $this->assertSame($placeholder, C\Placeholder::get());
+        $this->assertEquals('__', (string)$placeholder);
+    }
 }
 
 class TestSubject
 {
+    public function constant() {
+        return 1;
+    }
+
     public function identity($a) {
         return $a;
     }

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -258,6 +258,38 @@ class functionsTest extends TestCase
         $this->assertEquals(40, $subtractDouble(30, 100, 999));
     }
 
+    public function test_curry_fixed()
+    {
+        $subtractMulti = function($a, $b, $c = 1) {
+            return $a - ($b * $c);
+        };
+
+        $subtractFrom100 = C\curry(1, $subtractMulti, 100);
+        $this->assertInstanceOf('Closure', $subtractFrom100);
+        $this->assertEquals(70, $subtractFrom100(30, 10));
+
+        $subtractFrom100 = C\curry(2, $subtractMulti, 100);
+        $subtractDoubleFrom100 = $subtractFrom100(2);
+        $this->assertInstanceOf('Closure', $subtractDoubleFrom100);
+        $this->assertEquals(80, $subtractDoubleFrom100(10));
+    }
+
+    public function test_curry_right_fixed()
+    {
+        $subtractMulti = function($a, $b, $c = 1) {
+            return $a - ($b * $c);
+        };
+
+        $subtract100 = C\curry_right(1, $subtractMulti, 100);
+        $this->assertInstanceOf('Closure', $subtract100);
+        $this->assertEquals(200, $subtract100(300, 10));
+
+        $subtractDoubleFrom = C\curry_right(2, $subtractMulti, 2);
+        $subtractTwentyFrom = $subtractDoubleFrom(10);
+        $this->assertInstanceOf('Closure', $subtractTwentyFrom);
+        $this->assertEquals(80, $subtractTwentyFrom(100));
+    }
+
     public function test_rest()
     {
         $this->assertEquals(array(1), C\_rest(array(1, 1)));

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -214,17 +214,48 @@ class functionsTest extends TestCase
         $introduceOld = $introduce(C\__(), 99, C\__());
         $this->assertEquals("Foo, 99 years old, is a Developer and Cooker as well", $introduceOld('Foo', 'Developer', 'and Cooker as well'));
 
-        $introduceSkipName = $introduce(C\__());
-        $introduceSkipJob = $introduceSkipName(99, C\__());
-
-        $this->assertEquals("Foo, 99 years old, is a Cooker ", $introduceSkipJob('Foo', 'Cooker'));
-        $this->assertEquals("Foo, 99 years old, is a Cooker yumm !", $introduceSkipJob('Foo', 'Cooker', 'yumm !'));
+        $introduceOldDeveloper = $introduceDeveloper(C\__(), 99, C\__());
+        $this->assertEquals("Foo, 99 years old, is a Developer cool !", $introduceOldDeveloper('Foo', 'cool !'));
 
         $reduce = C\curry('array_reduce');
         $add = function($x, $y){ return $x + $y; };
         $sum = $reduce(C\__(), $add);
 
         $this->assertEquals(10, $sum(array(1, 2, 3, 4), 0));
+    }
+
+    public function test_curry_with_placeholders_and_optional_arg()
+    {
+        $subtractMulti = function($a, $b, $c = 1) {
+            return $a - ($b * $c);
+        };
+
+        $subtractDoubleFrom = C\curry($subtractMulti, C\__(), C\__(), 2);
+        $this->assertEquals(40, $subtractDoubleFrom(100, 30));
+
+        $subtractDoubleFrom100 = $subtractDoubleFrom(100);
+        $this->assertInstanceOf('Closure', $subtractDoubleFrom100);
+        $this->assertEquals(40, $subtractDoubleFrom100(30));
+
+        $subtractDoubleFrom = C\curry($subtractMulti, C\__(), C\__(), 2);
+        $this->assertEquals(40, $subtractDoubleFrom(100, 30, 999));
+    }
+
+    public function test_curry_right_with_placeholders_and_optional_arg()
+    {
+        $subtractMulti = function($a, $b, $c = 1) {
+            return $a - ($b * $c);
+        };
+
+        $subtractDouble = C\curry_right($subtractMulti, C\__(), C\__(), 2);
+        $this->assertEquals(40, $subtractDouble(30, 100));
+
+        $subtract60 = $subtractDouble(30);
+        $this->assertInstanceOf('Closure', $subtract60);
+        $this->assertEquals(40, $subtract60(100));
+
+        $subtractDouble = C\curry_right($subtractMulti, C\__(), C\__(), 2);
+        $this->assertEquals(40, $subtractDouble(30, 100, 999));
     }
 
     public function test_rest()
@@ -254,16 +285,6 @@ class functionsTest extends TestCase
             array(true, array(1, 2), array(new TestSubject(), 'add2')),
             array(true, array('aaa', 'a'), 'strpos'),
         );
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Argument Placeholder found on unexpected position !
-     */
-    public function test_unexpected_placeholder()
-    {
-        $fn = C\curry(function($a) { }, 22, C\__());
-        $fn(20);
     }
 
     public function test_placeholder()


### PR DESCRIPTION
The `curry_fixed` and `curry_right_fixed` methods are never implemented.

Rather than adding more functions, passing an integer as first arg specifies the number arguments.

```php
$divider = function ($a, $b, $c = 1) {
    return $a / ($b * $c);
};

$divide10ByProduct = C\curry(2, $divider, 10);
$divideByTripple = C\curry(2, $divider, 3);
$divideBy200 = C\curry_right(1, $divider, 10, 20);
```

This PR includes #9 