### PR TITLE
Added support for Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,28 @@ $division2 = C\curry_right_args($divider, [100, 10]);
 echo $division2(); // output 0.1
 ```
 
+### Operators
+
+Besides functions, it's also possible to curry operators. The following operators are supported:
+
+``` php
+use Cypress\Curry as C;
+
+$addTen = C\curry('+', 10);
+echo $addTen(4); // output 14
+
+$atLeast10 = C\curry('>=', 10);
+echo $atLeast10(1) ? 'more' : 'less'; // output less
+```
+
+| Operator types                                               |                                                |
+| ------------------------------------------------------------ | ---------------------------------------------- |
+| [Arithmetic Operators](https://php.net/operators.arithmetic) | `+`, `-`, `*`, `/`, `%`, `**`                  |
+| [Bitwise Operators](https://php.net/operators.bitwise)       | `&`, `∣`, `^`, `~`, `<<`, `>>`                 |
+| [Comparison Operators](https://php.net/operators.comparison) | `==`, `===`, `!=`, `!==`, `<`, `>`, `<=`, `>=` |
+| [Logical Operators](https://php.net/operators.logical)       | `and`/`&&`, `or`/`∣∣`, `xor`, `!`/`not`        |
+| [String Operator](https://php.net/operators.string)          | `.`                                            |
+
 ### Optional parameters
 
 Optional parameters and currying do not play very nicely together. This library excludes optional parameters by default.

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,15 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.6.0",
+        "ext-ctype": "*"
     },
     "autoload": {
         "psr-0": {"Cypress\\Curry": "src"},
-        "files": ["src/Cypress/Curry/functions.php"]
+        "files": [
+            "src/Cypress/Curry/functions.php",
+            "src/Cypress/Curry/operators.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "c06856be2361218ca4bd599f85e99088",
@@ -9,32 +9,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -59,41 +59,47 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -101,20 +107,122 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -155,33 +263,39 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -200,24 +314,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -247,37 +361,37 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -310,44 +424,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.0.3",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
-                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
                 "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^2.0",
-                "sebastian/version": "^2.0"
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -362,7 +476,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -373,20 +487,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-06T14:22:16+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -420,7 +534,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -514,29 +628,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -559,20 +673,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.0.8",
+            "version": "6.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6"
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
-                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0973426fb012359b2f18d3bd1e90ef1172839693",
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693",
                 "shasum": ""
             },
             "require": {
@@ -581,22 +695,24 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.3",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
                 "php": "^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^5.0",
-                "phpunit/php-file-iterator": "^1.4",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^4.0",
-                "sebastian/comparator": "^1.2.4 || ^2.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/environment": "^2.0",
-                "sebastian/exporter": "^2.0 || ^3.0",
-                "sebastian/global-state": "^1.1 || ^2.0",
-                "sebastian/object-enumerator": "^2.0 || ^3.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0"
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "3.0.2",
@@ -615,7 +731,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -641,33 +757,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-02T15:24:03+00:00"
+            "time": "2018-09-08T15:10:43+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.1",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "eabce450df194817a7d7e27e19013569a903a2bf"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/eabce450df194817a7d7e27e19013569a903a2bf",
-                "reference": "eabce450df194817a7d7e27e19013569a903a2bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
+                "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^3.0"
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -675,7 +791,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -690,7 +806,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -700,7 +816,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-03-03T06:30:20+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -749,30 +865,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.0",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
-                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/exporter": "^3.0"
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -803,38 +919,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-03-03T06:26:08+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -861,32 +977,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -911,20 +1027,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/b82d077cb3459e393abcf4867ae8f7230dcb51f6",
-                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
@@ -938,7 +1054,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -978,27 +1094,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-03-03T06:25:06+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1006,7 +1122,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1029,24 +1145,25 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.0",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "de6e32f7192dfea2e4bedc892434f4830b5c5794"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/de6e32f7192dfea2e4bedc892434f4830b5c5794",
-                "reference": "de6e32f7192dfea2e4bedc892434f4830b5c5794",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
                 "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
@@ -1075,7 +1192,52 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-03-03T06:21:01+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1216,17 +1378,57 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1263,7 +1465,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
     <testsuites>
         <testsuite name="php-curry test suite">
             <file>tests/Cypress/Curry/functions_test.php</file>
+            <file>tests/Cypress/Curry/operators_test.php</file>
         </testsuite>
     </testsuites>
 

--- a/src/Cypress/Curry/operators.php
+++ b/src/Cypress/Curry/operators.php
@@ -1,0 +1,395 @@
+<?php
+
+namespace Cypress\Curry;
+
+/**
+ * Addition; `+` operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_a979ef10cc6f6a36df6b8a323307ee3bb2e2db9c($a, $b)
+{
+    return $a + $b;
+}
+
+/**
+ * Subtraction; `-` operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_3bc15c8aae3e4124dd409035f32ea2fd6835efc9($a, $b)
+{
+    return $a - $b;
+}
+
+/**
+ * Multiplication; `*` operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_df58248c414f342c81e056b40bee12d17a08bf61($a, $b)
+{
+    return $a * $b;
+}
+
+/**
+ * Division; `/` operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8($a, $b)
+{
+    return $a / $b;
+}
+
+/**
+ * Modulo; `%` operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_4345cb1fa27885a8fbfe7c0c830a592cc76a552b($a, $b)
+{
+    return $a % $b;
+}
+
+/**
+ * Exponentiation; `**` operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32($a, $b)
+{
+    return $a ** $b;
+}
+
+
+/**
+ * Equal; '==' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_6947818ac409551f11fbaa78f0ea6391960aa5b8($a, $b)
+{
+    return $a == $b;
+}
+
+/**
+ * Identical; '===' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_b64cc2760536699c09c33fd0c38b16350e500872($a, $b)
+{
+    return $a === $b;
+}
+
+/**
+ * Not equal; '!=' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_d066fc085455ed98db6ac1badc818019c77c44ab($a, $b)
+{
+    return $a != $b;
+}
+
+/**
+ * Not identical; '!==' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_b7192c948f69d7776ba52c9d03f8632ec6afe9de($a, $b)
+{
+    return $a !== $b;
+}
+
+/**
+ * Less than; '<' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_c4dd3c8cdd8d7c95603dd67f1cd873d5f9148b29($a, $b)
+{
+    return $a < $b;
+}
+
+/**
+ * Greater than; '>' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_091385be99b45f459a231582d583ec9f3fa3d194($a, $b)
+{
+    return $a > $b;
+}
+
+/**
+ * Less than or equal to; '<=' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_8a681a2f041f4625cceacf20f0cf8ebf4248b5f1($a, $b)
+{
+    return $a <= $b;
+}
+
+/**
+ * Greater than or equal to; '>=' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return mixed
+ */
+function _operator_6c22e68f3b484db9779ac9e86488c2648313c410($a, $b)
+{
+    return $a >= $b;
+}
+
+/**
+ * Ternary; '?' operator ($if ? $then : $else)
+ *
+ * @internal
+ * @param bool  $if
+ * @param mixed $then
+ * @param mixed $else
+ * @return mixed
+ */
+function _operator_5bab61eb53176449e25c2c82f172b82cb13ffb9d($if, $then, $else)
+{
+    return $if ? $then : $else;
+}
+
+/**
+ * Elvis; '?:' operator ($select ?: $else)
+ *
+ * @internal
+ * @param mixed $select
+ * @param mixed $else
+ * @return mixed
+ */
+function _operator_e305f01faf8d7245a465629effccc67bc3d32ef7($select, $else)
+{
+    return $select ?: $else;
+}
+
+/**
+ * Concatenation; '.' operator
+ *
+ * @internal
+ * @param string $a
+ * @param string $b
+ * @return string
+ */
+function _operator_3a52ce780950d4d969792a2559cd519d7ee8c727($a, $b)
+{
+    return $a . $b;
+}
+
+/**
+ * Logical and; '&&' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_436f27a6ccf1ee52cf01c9775136ff5ecb4f3a72($a, $b)
+{
+    return $a && $b;
+}
+
+/**
+ * Logical and; 'and' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_and($a, $b)
+{
+    return $a && $b;
+}
+
+/**
+ * Logical or; '||' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_c65f37b2cb1ae26c89e9b4f26e2ca9e9cde4ae5b($a, $b)
+{
+    return $a || $b;
+}
+
+/**
+ * Logical or; 'or' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_or($a, $b)
+{
+    return $a || $b;
+}
+
+/**
+ * Logical xor; 'xor' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_xor($a, $b)
+{
+    return $a xor $b;
+}
+
+/**
+ * Logical not; '!' operator
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_0ab8318acaf6e678dd02e2b5c343ed41111b393d($a)
+{
+    return !$a;
+}
+
+/**
+ * Logical not (alias)
+ *
+ * @internal
+ * @param mixed $a
+ * @param mixed $b
+ * @return bool
+ */
+function _operator_not($a)
+{
+    return !$a;
+}
+
+
+/**
+ * Bitwise and; '&' operator
+ *
+ * @internal
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function _operator_7c4d33785daa5c2370201ffa236b427aa37c9996($a, $b)
+{
+    return $a & $b;
+}
+
+/**
+ * Bitwise or; '|' operator
+ *
+ * @internal
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function _operator_3eb416223e9e69e6bb8ee19793911ad1ad2027d8($a, $b)
+{
+    return $a | $b;
+}
+
+/**
+ * Bitwise xor; '^' operator
+ *
+ * @internal
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function _operator_5e6f80a34a9798cafc6a5db96cc57ba4c4db59c2($a, $b)
+{
+    return $a ^ $b;
+}
+
+/**
+ * Bitwise not; '~' operator
+ *
+ * @internal
+ * @param int $a
+ * @return int
+ */
+function _operator_fb3c6e4de85bd9eae26fdc63e75f10a7f39e850e($a)
+{
+    return ~$a;
+}
+
+/**
+ * Bitwise shift left; '<<' operator
+ *
+ * @internal
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function _operator_79047441987fa5937e857918d596ca65a8994f05($a, $b)
+{
+    return $a << $b;
+}
+
+/**
+ * Bitwise shift right; '>>' operator
+ *
+ * @internal
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function _operator_74562623d15859b6a47065e0f98ce1202fb56506($a, $b)
+{
+    return $a >> $b;
+}

--- a/tests/Cypress/Curry/functions_test.php
+++ b/tests/Cypress/Curry/functions_test.php
@@ -2,7 +2,6 @@
 
 namespace test\Cypress\Curry;
 
-use Cypress\Curry\CurriedFunction;
 use Cypress\Curry as C;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Cypress/Curry/operators_test.php
+++ b/tests/Cypress/Curry/operators_test.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace test\Cypress\Curry;
+
+use Cypress\Curry as C;
+use PHPUnit\Framework\TestCase;
+
+class operatorsTest extends TestCase
+{
+    function test_addition_operator()
+    {
+        $this->assertEquals(7, C\curry('+')(3, 4));
+        $this->assertEquals(11, C\curry('+', 5)(6));
+        $this->assertEquals(13, C\curry('+')(7)(6));
+        $this->assertEquals(17, C\curry('+', C\__(), -13)(30));
+        $this->assertEquals(['a' => 'e', 'I' => 'V'], C\curry('+', ['a' => 'e'])(['I' => 'V']));
+    }
+
+    function test_substraction_operator()
+    {
+        $this->assertEquals(3, C\curry('-')(7, 4));
+        $this->assertEquals(5, C\curry('-', 11)(6));
+        $this->assertEquals(7, C\curry('-')(13)(6));
+        $this->assertEquals(-13, C\curry('-', C\__(), 30)(17));
+    }
+
+    function test_multiplication_operator()
+    {
+        $this->assertEquals(12, C\curry('*')(3, 4));
+        $this->assertEquals(30, C\curry('*', 5)(6));
+        $this->assertEquals(42, C\curry('*')(7)(6));
+        $this->assertEquals(-390, C\curry('*', C\__(), -13)(30));
+    }
+
+    function test_devision_operator()
+    {
+        $this->assertEquals(3, C\curry('/')(12, 4));
+        $this->assertEquals(5.5, C\curry('/', 22)(4));
+        $this->assertEquals(10, C\curry('/')(100)(10));
+        $this->assertEquals(-7, C\curry('/', C\__(), 7)(-49));
+    }
+
+    function test_modulo_operator()
+    {
+        $this->assertEquals(0, C\curry('%')(12, 4));
+        $this->assertEquals(5, C\curry('%', 53)(8));
+        $this->assertEquals(7, C\curry('%')(67)(10));
+        $this->assertEquals(-13, C\curry('%', C\__(), 20)(-33));
+    }
+
+    function test_exponentiation_operator()
+    {
+        $this->assertEquals(25, C\curry('**', 5)(2));
+        $this->assertEquals(25, C\curry('**', 5)(2));
+        $this->assertEquals(1024, C\curry('**')(4)(5));
+        $this->assertEquals(-64, C\curry('**', C\__(), 3)(-4));
+    }
+
+
+    function test_equal_operator()
+    {
+        $this->assertTrue(C\curry('==')('foo', 'foo'));
+        $this->assertTrue(C\curry('==', 'bar')('bar'));
+        $this->assertFalse(C\curry('==')('foo')('bar'));
+        $this->assertTrue(C\curry('==', C\__(), 42)('42'));
+    }
+
+    function test_identical_operator()
+    {
+        $this->assertTrue(C\curry('===')('foo', 'foo'));
+        $this->assertTrue(C\curry('===', 'bar')('bar'));
+        $this->assertFalse(C\curry('===')('foo')('bar'));
+        $this->assertFalse(C\curry('===', C\__(), 42)('42'));
+    }
+
+    function test_not_equal_operator()
+    {
+        $this->assertFalse(C\curry('!=')('foo', 'foo'));
+        $this->assertFalse(C\curry('!=', 'foo')('foo'));
+        $this->assertTrue(C\curry('!=')('foo')('bar'));
+        $this->assertFalse(C\curry('!=', C\__(), 42)('42'));
+    }
+
+    function test_not_identical_operator()
+    {
+        $this->assertFalse(C\curry('!==')('foo', 'foo'));
+        $this->assertFalse(C\curry('!==', 'bar')('bar'));
+        $this->assertTrue(C\curry('!==')('foo')('bar'));
+        $this->assertTrue(C\curry('!==', C\__(), 42)('42'));
+    }
+
+    function test_less_than_operator()
+    {
+        $this->assertTrue(C\curry('<')(3, 10));
+        $this->assertTrue(C\curry_right('<')('foo')('bar'));
+        $this->assertFalse(C\curry_right('<', 42)(42));
+        $this->assertFalse(C\curry('<', C\__(), 42)(100));
+    }
+
+    function test_greater_than_operator()
+    {
+        $this->assertFalse(C\curry('>')(3, 10));
+        $this->assertFalse(C\curry_right('>')('foo')('bar'));
+        $this->assertFalse(C\curry_right('>', 42)(42));
+        $this->assertTrue(C\curry('>', C\__(), 42)(100));
+    }
+
+    function test_less_than_or_equal_to_operator()
+    {
+        $this->assertTrue(C\curry('<=')(3, 10));
+        $this->assertTrue(C\curry_right('<=')('foo')('bar'));
+        $this->assertTrue(C\curry_right('<=', 42)(42));
+        $this->assertFalse(C\curry('<=', C\__(), 42)(100));
+    }
+
+    function test_greater_than_or_equal_operator()
+    {
+        $this->assertFalse(C\curry('>=')(3, 10));
+        $this->assertFalse(C\curry_right('>=')('foo')('bar'));
+        $this->assertTrue(C\curry_right('>=', 42)(42));
+        $this->assertTrue(C\curry('>=', C\__(), 42)(100));
+    }
+
+
+    function test_ternary_operator()
+    {
+        $this->assertEquals(7, C\curry('?', C\__(), 7, 9)(true));
+        $this->assertEquals(9, C\curry('?', C\__(), 7, 9)(false));
+        $this->assertEquals(7, C\curry_right('?', C\__(), C\__(), 9)(7)(true));
+    }
+
+    function test_elvis_operator()
+    {
+        $this->assertEquals(7, C\curry('?:', C\__(), 100)(7));
+        $this->assertEquals(100, C\curry('?:', C\__(), 100)(0));
+
+        $this->assertEquals(7, C\curry('?:', 7)(9));
+        $this->assertEquals(7, C\curry('?:', 0)(7));
+    }
+
+    function test_concatenation_operator()
+    {
+        $this->assertEquals('ab', C\curry('.')('a', 'b'));
+        $this->assertEquals('ab', C\curry('.', 'a')('b'));
+        $this->assertEquals('ab', C\curry('.')('a')('b'));
+        $this->assertEquals('ab', C\curry('.', C\__(), 'b')('a'));
+    }
+
+
+    function and_provider()
+    {
+        return [['&&'], ['and']];
+    }
+
+    /**
+     * @dataProvider and_provider
+     */
+    function test_and_operator($op)
+    {
+        $this->assertFalse(C\curry($op)(false, false));
+        $this->assertFalse(C\curry($op, true)(false));
+        $this->assertFalse(C\curry($op)(false)(true));
+        $this->assertTrue(C\curry($op, C\__(), true)(true));
+    }
+
+    function or_provider()
+    {
+        return [['||'], ['or']];
+    }
+
+    /**
+     * @dataProvider or_provider
+     */
+    function test_or_operator($op)
+    {
+        $this->assertFalse(C\curry($op)(false, false));
+        $this->assertTrue(C\curry($op, true)(false));
+        $this->assertTrue(C\curry($op)(false)(true));
+        $this->assertTrue(C\curry($op, C\__(), true)(true));
+    }
+
+    function test_xor_operator()
+    {
+        $this->assertFalse(C\curry('xor')(false, false));
+        $this->assertTrue(C\curry('xor', true)(false));
+        $this->assertTrue(C\curry('xor')(false)(true));
+        $this->assertFalse(C\curry('xor', C\__(), true)(true));
+    }
+
+    function not_provider()
+    {
+        return [['!'], ['not']];
+    }
+
+    /**
+     * @dataProvider not_provider
+     */
+    function test_not_operator($op)
+    {
+        $this->assertTrue(C\curry($op)(false));
+        $this->assertFalse(C\curry($op, C\__())(1));
+    }
+
+
+    function test_bitwise_and()
+    {
+        $this->assertEquals(0b10100000, C\curry('&')(0b10101010)(0b11110000));
+        $this->assertEquals(0b00001010, C\curry('&', C\__(), 0b00001111)(0b10101010));
+    }
+
+    function test_bitwise_or()
+    {
+        $this->assertEquals(0b11111010, C\curry('|')(0b10101010)(0b11110000));
+        $this->assertEquals(0b10101111, C\curry('|', C\__(), 0b00001111)(0b10101010));
+    }
+
+    function test_bitwise_xor()
+    {
+        $this->assertEquals(0b01011010, C\curry('^')(0b10101010)(0b11110000));
+        $this->assertEquals(0b10100101, C\curry('^', C\__(), 0b00001111)(0b10101010));
+    }
+
+    function test_bitwise_not()
+    {
+        $this->assertEquals(~0b10100000, C\curry('~')(0b10100000));
+    }
+
+    function test_bitwise_shift_left()
+    {
+        $this->assertEquals(0b10100000, C\curry('<<')(0b00001010)(4));
+        $this->assertEquals(0b10100000, C\curry('<<', C\__(), 4)(0b00001010));
+    }
+
+    function test_bitwise_shift_right()
+    {
+        $this->assertEquals(0b00001010, C\curry('>>')(0b10100000)(4));
+        $this->assertEquals(0b00001010, C\curry('>>', C\__(), 4)(0b10100000));
+    }
+
+
+    function test_operator_args()
+    {
+        $this->assertEquals(3, C\curry_args('-', [5])(2));
+    }
+
+    function test_operator_right_args()
+    {
+        $this->assertEquals(3, C\curry_right_args('-', [2])(5));
+    }
+
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Operator '=' can't be used as curry function
+     */
+    function test_assignment_operator()
+    {
+        C\curry('=')('foo', 'bar');
+    }
+}


### PR DESCRIPTION
 ``` php
use Cypress\Curry as C;

$addTen = C\curry('+', 10);
echo $addTen(4); // output 14

$atLeast10 = C\curry('>=', 10);
echo $atLeast10(1) ? 'more' : 'less'; // output less
```

 | Operator types                                               |                                                |
| ------------------------------------------------------------ | ---------------------------------------------- |
| [Arithmetic Operators](https://php.net/operators.arithmetic) | `+`, `-`, `*`, `/`, `%`, `**`                  |
| [Bitwise Operators](https://php.net/operators.bitwise)       | `&`, `∣`, `^`, `~`, `<<`, `>>`                 |
| [Comparison Operators](https://php.net/operators.comparison) | `==`, `===`, `!=`, `!==`, `<`, `>`, `<=`, `>=` |
| [Logical Operators](https://php.net/operators.logical)       | `and`/`&&`, `or`/`∣∣`, `xor`, `!`/`not`        |
| [String Operator](https://php.net/operators.string)          | `.`                                            |